### PR TITLE
feat: add application tables to database migration

### DIFF
--- a/app/bouncer/migrations/2025-12-26T00-52-06.163Z.sql
+++ b/app/bouncer/migrations/2025-12-26T00-52-06.163Z.sql
@@ -11,3 +11,51 @@ create index "session_userId_idx" on "session" ("userId");
 create index "account_userId_idx" on "account" ("userId");
 
 create index "verification_identifier_idx" on "verification" ("identifier");
+
+-- Application Tables
+
+-- Enable UUID generation (available by default in PostgreSQL 13+, or via pgcrypto extension)
+create extension if not exists "pgcrypto";
+
+create table "party" (
+  "party_id" uuid primary key default gen_random_uuid(),
+  "name" text not null,
+  "time" timestamptz not null,
+  "location" text not null,
+  "description" text,
+  "slug" text not null unique,
+  "created_at" timestamptz default CURRENT_TIMESTAMP not null,
+  "updated_at" timestamptz default CURRENT_TIMESTAMP not null,
+  "deleted_at" timestamptz
+);
+
+create table "guest" (
+  "guest_id" uuid primary key default gen_random_uuid(),
+  "user_id" text not null references "user" ("id") on delete cascade,
+  "name" text not null,
+  "email" text not null,
+  "phone" text,
+  "created_at" timestamptz default CURRENT_TIMESTAMP not null,
+  "updated_at" timestamptz default CURRENT_TIMESTAMP not null,
+  "deleted_at" timestamptz
+);
+
+create table "rsvp" (
+  "rsvp_id" uuid primary key default gen_random_uuid(),
+  "party_id" uuid not null references "party" ("party_id") on delete cascade,
+  "guest_id" uuid not null references "guest" ("guest_id") on delete cascade,
+  "status" text not null,
+  "created_at" timestamptz default CURRENT_TIMESTAMP not null,
+  "updated_at" timestamptz default CURRENT_TIMESTAMP not null,
+  "deleted_at" timestamptz,
+  unique ("party_id", "guest_id")
+);
+
+create index "party_slug_idx" on "party" ("slug");
+create index "party_deleted_at_idx" on "party" ("deleted_at");
+create index "guest_user_id_idx" on "guest" ("user_id");
+create index "guest_email_idx" on "guest" ("email");
+create index "guest_deleted_at_idx" on "guest" ("deleted_at");
+create index "rsvp_party_id_idx" on "rsvp" ("party_id");
+create index "rsvp_guest_id_idx" on "rsvp" ("guest_id");
+create index "rsvp_deleted_at_idx" on "rsvp" ("deleted_at");


### PR DESCRIPTION
## Summary
- Added party, guest, and rsvp tables to the database migration based on RFD-006 schemas
- Updated guest table to reference Better Auth user table instead of Ory identity
- Enabled pgcrypto extension for PostgreSQL UUID generation compatibility
- Added performance indexes for common query patterns (slug lookups, soft deletes, foreign key relationships)

## Test plan
- [ ] Verify migration runs successfully on Neon PostgreSQL
- [ ] Confirm all tables are created with correct schema
- [ ] Validate foreign key constraints work correctly
- [ ] Test that indexes are created properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)