### PR TITLE
Block RSVP changes after party cutoff

### DIFF
--- a/app/bouncer/app/parties/[slug]/__tests__/rsvp.test.tsx
+++ b/app/bouncer/app/parties/[slug]/__tests__/rsvp.test.tsx
@@ -31,7 +31,7 @@ describe("RsvpForm", () => {
   });
 
   it("displays current RSVP status", async () => {
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Current Status/i)).toBeInTheDocument();
@@ -50,7 +50,7 @@ describe("RsvpForm", () => {
   });
 
   it("displays status options for updating", async () => {
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       // Check that all status buttons are present
@@ -63,7 +63,7 @@ describe("RsvpForm", () => {
   });
 
   it("disables current status button", async () => {
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       const pendingButton = screen
@@ -78,7 +78,7 @@ describe("RsvpForm", () => {
     const updatedRsvp = { ...mockRsvp, status: "accepted" };
     (updateRsvpClient as jest.Mock).mockResolvedValue(updatedRsvp);
 
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Current Status/i)).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe("RsvpForm", () => {
       new Error("Network error")
     );
 
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Current Status/i)).toBeInTheDocument();
@@ -153,7 +153,7 @@ describe("RsvpForm", () => {
     });
     (updateRsvpClient as jest.Mock).mockReturnValue(updatePromise);
 
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Current Status/i)).toBeInTheDocument();
@@ -195,7 +195,7 @@ describe("RsvpForm", () => {
   it("does not update if clicking current status", async () => {
     const user = userEvent.setup();
 
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Current Status/i)).toBeInTheDocument();
@@ -218,7 +218,7 @@ describe("RsvpForm", () => {
     const updatedRsvp = { ...mockRsvp, status: "accepted" };
     (updateRsvpClient as jest.Mock).mockResolvedValue(updatedRsvp);
 
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Current Status/i)).toBeInTheDocument();
@@ -256,7 +256,7 @@ describe("RsvpForm", () => {
   it("handles different initial statuses correctly", async () => {
     const acceptedRsvp = { ...mockRsvp, status: "accepted" };
     (fetchRsvpClient as jest.Mock).mockResolvedValue(acceptedRsvp);
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       // Check for status in the status display area
@@ -269,7 +269,7 @@ describe("RsvpForm", () => {
   });
 
   it("displays correct status colors", async () => {
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       // Check that status display has appropriate styling
@@ -287,7 +287,7 @@ describe("RsvpForm", () => {
     (fetchRsvpClient as jest.Mock).mockImplementation(
       () => new Promise(() => {}) // Never resolves
     );
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     // Loading text should appear in the status display
     const statusDisplay = screen
@@ -309,7 +309,7 @@ describe("RsvpForm", () => {
     (fetchRsvpClient as jest.Mock).mockRejectedValue(
       new Error("Failed to load RSVP")
     );
-    render(<RsvpForm partyId="party-123" />);
+    render(<RsvpForm partyId="party-123" isClosed={false} />);
 
     await waitFor(() => {
       // Error should appear in the status display area

--- a/app/bouncer/app/parties/[slug]/party-detail-wrapper.tsx
+++ b/app/bouncer/app/parties/[slug]/party-detail-wrapper.tsx
@@ -16,7 +16,9 @@ export function PartyDetailWrapper({
   partyRsvpsError,
   currentUserId,
 }: PartyDetailWrapperProps) {
+  const graceMs = 24 * 60 * 60 * 1000;
   const partyDate = new Date(party.time);
+  const isClosed = Date.now() > partyDate.getTime() + graceMs;
   const formattedDate = partyDate.toLocaleDateString("en-US", {
     weekday: "long",
     year: "numeric",
@@ -66,7 +68,7 @@ export function PartyDetailWrapper({
 
         <div className="mb-8">
           <h2 className="text-2xl mb-4 text-black/90">RSVP</h2>
-          <RsvpForm partyId={party.party_id} />
+          <RsvpForm partyId={party.party_id} isClosed={isClosed} />
         </div>
 
         <div className="mb-8">

--- a/app/bouncer/app/parties/[slug]/rsvp-form.tsx
+++ b/app/bouncer/app/parties/[slug]/rsvp-form.tsx
@@ -6,9 +6,10 @@ import { fetchRsvpClient, updateRsvpClient } from "@/lib/api-client-client";
 
 interface RsvpFormProps {
   partyId: string;
+  isClosed: boolean;
 }
 
-export function RsvpForm({ partyId }: RsvpFormProps) {
+export function RsvpForm({ partyId, isClosed }: RsvpFormProps) {
   const [rsvp, setRsvp] = useState<Rsvp | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -33,7 +34,7 @@ export function RsvpForm({ partyId }: RsvpFormProps) {
   }, [partyId]);
 
   const handleStatusChange = async (newStatus: string) => {
-    if (!rsvp || newStatus === rsvp.status) {
+    if (!rsvp || newStatus === rsvp.status || isClosed) {
       return; // No change needed
     }
 
@@ -106,11 +107,16 @@ export function RsvpForm({ partyId }: RsvpFormProps) {
   };
 
   const hasUnrecoverableError = error && !rsvp;
-  const isDisabled = isLoading || isUpdating || hasUnrecoverableError;
+  const isDisabled = isLoading || isUpdating || hasUnrecoverableError || isClosed;
 
   return (
     <div className="space-y-4">
       <div className="p-4 bg-white/5 rounded border border-white/10">
+        {isClosed && (
+          <div className="mb-4 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            RSVPs are closed for this party.
+          </div>
+        )}
         <div className="mb-4">
           <p className="text-sm opacity-80 mb-2">Current Status</p>
           <p className={`text-lg font-semibold ${getStatusTextColor()}`}>

--- a/app/bouncer/app/parties/housewarming-2024/housewarming-invitation.tsx
+++ b/app/bouncer/app/parties/housewarming-2024/housewarming-invitation.tsx
@@ -19,7 +19,9 @@ export function HousewarmingInvitation({
   partyRsvpsError,
   currentUserId,
 }: HousewarmingInvitationProps) {
+  const graceMs = 24 * 60 * 60 * 1000;
   const partyDate = new Date(party.time);
+  const isClosed = Date.now() > partyDate.getTime() + graceMs;
   const formattedDate = partyDate.toLocaleDateString("en-US", {
     weekday: "long",
     year: "numeric",
@@ -80,7 +82,7 @@ export function HousewarmingInvitation({
             <h2 className="text-xl md:text-3xl font-bold mb-4 md:mb-6 text-black">
               RSVP
             </h2>
-            <RsvpForm partyId={party.party_id} />
+            <RsvpForm partyId={party.party_id} isClosed={isClosed} />
           </div>
 
           {/* Guest list section */}

--- a/app/bouncer/lib/__tests__/api-client-client.test.ts
+++ b/app/bouncer/lib/__tests__/api-client-client.test.ts
@@ -95,6 +95,18 @@ describe("api-client-client", () => {
       ).rejects.toThrow("RSVP not found");
     });
 
+    it("handles 409 conflict error", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+      } as Response);
+
+      await expect(
+        updateRsvpClient({ rsvp_id: "rsvp-123", status: "accepted" })
+      ).rejects.toThrow("RSVPs are closed for this party");
+    });
+
     it("handles 500 server error", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/app/bouncer/lib/__tests__/api-client.test.ts
+++ b/app/bouncer/lib/__tests__/api-client.test.ts
@@ -255,6 +255,18 @@ describe("api-client", () => {
         "Party or user not found"
       );
     });
+
+    it("handles 409 conflict error", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+      } as Response);
+
+      await expect(fetchRsvp("party-123")).rejects.toThrow(
+        "RSVPs are closed for this party"
+      );
+    });
   });
 
   describe("fetchPartyRsvps", () => {
@@ -407,6 +419,18 @@ describe("api-client", () => {
       await expect(
         updateRsvp({ rsvp_id: "rsvp-123", status: "accepted" })
       ).rejects.toThrow("RSVP not found");
+    });
+
+    it("handles 409 conflict error", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+      } as Response);
+
+      await expect(
+        updateRsvp({ rsvp_id: "rsvp-123", status: "accepted" })
+      ).rejects.toThrow("RSVPs are closed for this party");
     });
   });
 });

--- a/app/bouncer/lib/api-client-client.ts
+++ b/app/bouncer/lib/api-client-client.ts
@@ -63,6 +63,9 @@ export async function fetchRsvpClient(partyId: string): Promise<Rsvp> {
     if (response.status === 404) {
       throw new Error("Party or user not found");
     }
+    if (response.status === 409) {
+      throw new Error("RSVPs are closed for this party");
+    }
     if (response.status === 500) {
       throw new Error("Server error: Unable to fetch RSVP");
     }
@@ -98,6 +101,9 @@ export async function updateRsvpClient(
     }
     if (response.status === 404) {
       throw new Error("RSVP not found");
+    }
+    if (response.status === 409) {
+      throw new Error("RSVPs are closed for this party");
     }
     if (response.status === 500) {
       throw new Error("Server error: Unable to update RSVP");

--- a/app/bouncer/lib/api-client.ts
+++ b/app/bouncer/lib/api-client.ts
@@ -152,6 +152,9 @@ export async function fetchRsvp(partyId: string): Promise<Rsvp> {
     if (response.status === 404) {
       throw new Error("Party or user not found");
     }
+    if (response.status === 409) {
+      throw new Error("RSVPs are closed for this party");
+    }
     if (response.status === 500) {
       throw new Error("Server error: Unable to fetch RSVP");
     }
@@ -225,6 +228,9 @@ export async function updateRsvp(
     }
     if (response.status === 404) {
       throw new Error("RSVP not found");
+    }
+    if (response.status === 409) {
+      throw new Error("RSVPs are closed for this party");
     }
     if (response.status === 500) {
       throw new Error("Server error: Unable to update RSVP");

--- a/app/bouncer/package-lock.json
+++ b/app/bouncer/package-lock.json
@@ -95,6 +95,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -573,6 +574,7 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.10.tgz",
       "integrity": "sha512-AThrfb6CpG80wqkanfrbN2/fGOYzhGladHFf3JhaWt/3/Vtf4h084T6PJLrDE7M/vCCGYvDI1DkvP3P1OB2HAg==",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.1.12"
@@ -621,12 +623,14 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.7.1",
@@ -2245,6 +2249,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2671,6 +2676,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2998,6 +3004,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3008,6 +3015,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3039,6 +3047,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
       "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
@@ -3123,6 +3132,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -3654,6 +3664,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4190,6 +4201,7 @@
       "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.10.tgz",
       "integrity": "sha512-0kqwEBJLe8eyFzbUspRG/htOriCf9uMLlnpe34dlIJGdmDfPuQISd4shShvUrvIVhPxsY1dSTXdXPLpqISYOYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.4.10",
         "@better-auth/telemetry": "1.4.10",
@@ -4286,6 +4298,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
       "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
         "@better-fetch/fetch": "^1.1.4",
@@ -4354,6 +4367,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5329,6 +5343,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5530,6 +5545,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7871,6 +7887,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8036,6 +8053,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
       "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -8659,6 +8677,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -8691,6 +8710,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.10.tgz",
       "integrity": "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.0.10",
         "@swc/helpers": "0.5.15",
@@ -9123,6 +9143,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9388,6 +9409,7 @@
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.2.tgz",
       "integrity": "sha512-7DwuT7Tkst41ZjSj287g7C9c5/D3Xx5rMgBosg0dadbUPoZD2HNzkadKPol1d2PJAoI9f+Jeh1/v9YfLzpFGVw==",
       "license": "Zlib",
+      "peer": true,
       "peerDependencies": {
         "three": ">= 0.157.0 < 0.183.0"
       }
@@ -9585,6 +9607,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9594,6 +9617,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10624,7 +10648,8 @@
       "version": "0.169.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
       "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -10699,6 +10724,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11005,6 +11031,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11551,6 +11578,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/pregame/src/api/rsvp.rs
+++ b/app/pregame/src/api/rsvp.rs
@@ -11,6 +11,16 @@ use crate::api::ApiState;
 use crate::auth::BetterAuthSession;
 use crate::model::{Rsvp, RsvpWithUser};
 
+const RSVP_GRACE_HOURS: i64 = 24;
+const RSVP_CLOSED_MESSAGE: &str = "RSVPs are closed for this party";
+
+fn is_rsvp_closed(
+    party_time: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    party_time < now - chrono::Duration::hours(RSVP_GRACE_HOURS)
+}
+
 /// Get RSVPs for a specific party
 pub async fn get_party_rsvps(
     State(api_state): State<Arc<ApiState>>,
@@ -84,6 +94,40 @@ async fn get_rsvp_impl(
 
     // Get a connection from the pool
     let client = api_state.db_state.get_connection().await?;
+
+    let party_time_row = client
+        .query_opt(
+            "SELECT time FROM party WHERE party_id = $1 AND deleted_at IS NULL;",
+            &[&party_id],
+        )
+        .await
+        .map_err(|err| {
+            tracing::error!("Database query failed: {:?}", err);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json("Internal Server Error"),
+            )
+                .into_response()
+        })?;
+
+    let Some(party_time_row) = party_time_row else {
+        return Err((StatusCode::NOT_FOUND, Json("Party not found")).into_response());
+    };
+
+    let party_time: chrono::DateTime<chrono::Utc> = party_time_row
+        .try_get("time")
+        .map_err(|err| {
+            tracing::error!("Failed to parse party time from row: {:?}", err);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json("Internal Server Error"),
+            )
+                .into_response()
+        })?;
+
+    if is_rsvp_closed(party_time, now) {
+        return Err((StatusCode::CONFLICT, Json(RSVP_CLOSED_MESSAGE)).into_response());
+    }
 
     // Single query: validate party exists, insert if not exists, then select the RSVP
     let row = client
@@ -178,6 +222,46 @@ async fn update_rsvp_impl(
     // Get a connection from the pool
     let client = api_state.db_state.get_connection().await?;
 
+    let party_time_row = client
+        .query_opt(
+            "SELECT p.time
+             FROM party p
+             JOIN rsvp r ON r.party_id = p.party_id
+             WHERE r.rsvp_id = $1
+               AND r.user_id = $2
+               AND r.deleted_at IS NULL
+               AND p.deleted_at IS NULL;",
+            &[&payload.rsvp_id, &user_id],
+        )
+        .await
+        .map_err(|err| {
+            tracing::error!("Database query failed: {:?}", err);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json("Internal Server Error"),
+            )
+                .into_response()
+        })?;
+
+    let Some(party_time_row) = party_time_row else {
+        return Err((StatusCode::NOT_FOUND, Json("RSVP not found")).into_response());
+    };
+
+    let party_time: chrono::DateTime<chrono::Utc> = party_time_row
+        .try_get("time")
+        .map_err(|err| {
+            tracing::error!("Failed to parse party time from row: {:?}", err);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json("Internal Server Error"),
+            )
+                .into_response()
+        })?;
+
+    if is_rsvp_closed(party_time, now) {
+        return Err((StatusCode::CONFLICT, Json(RSVP_CLOSED_MESSAGE)).into_response());
+    }
+
     // Only allow users to update their own RSVPs
     let row = client
         .query_opt(
@@ -232,6 +316,46 @@ async fn delete_rsvp_impl(
 
     // Get a connection from the pool
     let client = api_state.db_state.get_connection().await?;
+
+    let party_time_row = client
+        .query_opt(
+            "SELECT p.time
+             FROM party p
+             JOIN rsvp r ON r.party_id = p.party_id
+             WHERE r.party_id = $1
+               AND r.user_id = $2
+               AND r.deleted_at IS NULL
+               AND p.deleted_at IS NULL;",
+            &[&party_id, &user_id],
+        )
+        .await
+        .map_err(|err| {
+            tracing::error!("Database query failed: {:?}", err);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json("Internal Server Error"),
+            )
+                .into_response()
+        })?;
+
+    let Some(party_time_row) = party_time_row else {
+        return Err((StatusCode::NOT_FOUND, Json("RSVP not found")).into_response());
+    };
+
+    let party_time: chrono::DateTime<chrono::Utc> = party_time_row
+        .try_get("time")
+        .map_err(|err| {
+            tracing::error!("Failed to parse party time from row: {:?}", err);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json("Internal Server Error"),
+            )
+                .into_response()
+        })?;
+
+    if is_rsvp_closed(party_time, now) {
+        return Err((StatusCode::CONFLICT, Json(RSVP_CLOSED_MESSAGE)).into_response());
+    }
 
     let rows_affected = client
         .execute(


### PR DESCRIPTION
## Summary
- block RSVP mutations once party is more than 24h past start\n- return 409 conflict and surface closed messaging in clients/UI
- update tests for 409 handling\n\n

## Testing
- npm test (fails in app/bouncer: Jest ESM parsing for @react-three/postprocessing; unrelated to this change)