### PR TITLE
[codex] Add May 30 cloud invitation

### DIFF
--- a/app/bouncer/app/invitations/__tests__/page.test.tsx
+++ b/app/bouncer/app/invitations/__tests__/page.test.tsx
@@ -33,6 +33,14 @@ jest.mock("@/lib/api-client", () => ({
   fetchParties: jest.fn(),
 }));
 
+jest.mock("@/lib/webgl/receipt-canvas", () => ({
+  ReceiptCanvas: () => <div data-testid="receipt-canvas" />,
+}));
+
+jest.mock("@/lib/webgl/cloud-canvas", () => ({
+  CloudCanvas: () => <div data-testid="cloud-canvas" />,
+}));
+
 jest.mock("next/headers", () => ({
   headers: jest.fn(),
 }));
@@ -299,7 +307,21 @@ describe("InvitationsPage", () => {
 
   it("creates clickable links to party detail pages", async () => {
     const { fetchParties } = require("@/lib/api-client");
-    fetchParties.mockResolvedValue(mockParties);
+    fetchParties.mockResolvedValue([
+      ...mockParties,
+      {
+        party_id: "party-3",
+        name: "What's the Move?",
+        time: "2026-05-31T00:00:00Z",
+        location: "TBD",
+        description:
+          "A practical check-in on whether I should stay in New York or make a different move.",
+        slug: "whats-the-move-2026",
+        created_at: "2026-05-10T00:00:00Z",
+        updated_at: "2026-05-10T00:00:00Z",
+        deleted_at: null,
+      },
+    ]);
 
     const component = await InvitationsPage();
     render(component);
@@ -309,11 +331,10 @@ describe("InvitationsPage", () => {
       link.getAttribute("href")?.startsWith("/parties/")
     );
 
-    expect(partyLinks.length).toBe(2);
-    expect(partyLinks[0]?.getAttribute("href")).toBe(
-      "/parties/new-years-party"
-    );
-    expect(partyLinks[1]?.getAttribute("href")).toBe("/parties/summer-bbq");
+    const hrefs = partyLinks.map((link) => link.getAttribute("href"));
+    expect(hrefs).toContain("/parties/new-years-party");
+    expect(hrefs).toContain("/parties/summer-bbq");
+    expect(hrefs).toContain("/parties/whats-the-move-2026");
   });
 
   it("displays party date and time correctly", async () => {
@@ -380,7 +401,7 @@ describe("InvitationsPage", () => {
     expect(actionsContainer?.className).toContain("flex-col");
   });
 
-  it("positions actions after invitations section", async () => {
+  it("positions actions after the invitations section", async () => {
     const { fetchParties } = require("@/lib/api-client");
     fetchParties.mockResolvedValue([]);
 
@@ -393,7 +414,7 @@ describe("InvitationsPage", () => {
     expect(invitationsHeading).toBeTruthy();
     expect(settingsLink).toBeTruthy();
 
-    // Check that actions come after the invitations section in the DOM
+    // Check that actions come after the invitations section in the DOM.
     const invitationsSection = invitationsHeading.closest("div");
     const actionsContainer = settingsLink.closest("div");
 

--- a/app/bouncer/app/invitations/next-party-highlight.tsx
+++ b/app/bouncer/app/invitations/next-party-highlight.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Party } from "@/lib/types";
 import { ReceiptCanvas } from "@/lib/webgl/receipt-canvas";
+import { CloudCanvas } from "@/lib/webgl/cloud-canvas";
 import { LocalDateTime } from "@/app/components/local-date-time";
 
 interface NextPartyHighlightProps {
@@ -10,6 +11,7 @@ interface NextPartyHighlightProps {
 export function NextPartyHighlight({ party }: NextPartyHighlightProps) {
   const hasReceiptPreview =
     party.slug === "housewarming-2024" || party.slug === "launch-party-2026";
+  const hasCloudPreview = party.slug === "whats-the-move-2026";
 
   return (
     <div className="mb-4 md:mb-8">
@@ -32,18 +34,37 @@ export function NextPartyHighlight({ party }: NextPartyHighlightProps) {
                   />
                 </div>
               )}
+              {hasCloudPreview && (
+                <div className="absolute inset-0 rounded-lg overflow-hidden z-0">
+                  <CloudCanvas className="h-full w-full" compact />
+                </div>
+              )}
 
               {/* Content */}
               <div className="relative z-10 flex h-full flex-col justify-between">
                 <div>
-                  <h3 className="text-lg md:text-xl font-semibold mb-4 text-black/90 hover:text-black transition-colors text-left leading-tight line-clamp-3 break-words">
+                  <h3
+                    className={`text-base md:text-lg font-semibold mb-3 transition-colors text-left leading-tight line-clamp-3 break-words ${
+                      hasCloudPreview
+                        ? "text-black/90 hover:text-black"
+                        : "text-black/90 hover:text-black"
+                    }`}
+                  >
                     {party.name}
                   </h3>
-                  <p className="text-sm text-black/70 text-left leading-relaxed">
+                  <p
+                    className={`text-xs text-left leading-relaxed ${
+                      hasCloudPreview ? "text-black/70" : "text-black/70"
+                    }`}
+                  >
                     <LocalDateTime dateTime={party.time} mode="date" />
                   </p>
                 </div>
-                <span className="inline-flex self-start items-center gap-1 text-[11px] uppercase tracking-[0.14em] text-black/55">
+                <span
+                  className={`inline-flex self-start items-center gap-1 text-[10px] uppercase tracking-[0.14em] ${
+                    hasCloudPreview ? "text-black/55" : "text-black/55"
+                  }`}
+                >
                   open invitation <span aria-hidden="true">↗</span>
                 </span>
               </div>
@@ -53,7 +74,7 @@ export function NextPartyHighlight({ party }: NextPartyHighlightProps) {
 
         {/* Description - to the right of the card */}
         <div className="flex-1 min-w-0 pt-1 md:pt-2">
-          <div className="text-base md:text-2xl text-black/80 leading-tight tracking-tighter break-words">
+          <div className="text-sm md:text-xl text-black/80 leading-tight tracking-tighter break-words">
             {party.description || (
               <span className="opacity-60 italic">
                 No description available.

--- a/app/bouncer/app/invitations/party-card.tsx
+++ b/app/bouncer/app/invitations/party-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Party } from "@/lib/types";
 import { ReceiptCanvas } from "@/lib/webgl/receipt-canvas";
+import { CloudCanvas } from "@/lib/webgl/cloud-canvas";
 import { LocalDateTime } from "@/app/components/local-date-time";
 
 interface PartyCardProps {
@@ -10,6 +11,7 @@ interface PartyCardProps {
 export function PartyCard({ party }: PartyCardProps) {
   const hasReceiptPreview =
     party.slug === "housewarming-2024" || party.slug === "launch-party-2026";
+  const hasCloudPreview = party.slug === "whats-the-move-2026";
 
   return (
     <div className="group w-[calc(50%-0.5rem)] md:w-auto">
@@ -25,13 +27,28 @@ export function PartyCard({ party }: PartyCardProps) {
               />
             </div>
           )}
+          {hasCloudPreview && (
+            <div className="absolute inset-0 rounded-lg overflow-hidden z-0">
+              <CloudCanvas className="h-full w-full" compact />
+            </div>
+          )}
 
           {/* Content */}
           <div className="relative z-10 flex flex-col h-full justify-start">
-            <h3 className="text-xl font-semibold mb-4 text-black/90 group-hover:text-black transition-colors text-left line-clamp-3">
+            <h3
+              className={`text-xl font-semibold mb-4 transition-colors text-left line-clamp-3 ${
+                hasCloudPreview
+                  ? "text-black/90 group-hover:text-black"
+                  : "text-black/90 group-hover:text-black"
+              }`}
+            >
               {party.name}
             </h3>
-            <p className="text-sm text-black/70 text-left leading-relaxed">
+            <p
+              className={`text-sm text-left leading-relaxed ${
+                hasCloudPreview ? "text-black/70" : "text-black/70"
+              }`}
+            >
               <LocalDateTime dateTime={party.time} mode="date" />
             </p>
           </div>

--- a/app/bouncer/app/parties/whats-the-move-2026/__tests__/page.test.tsx
+++ b/app/bouncer/app/parties/whats-the-move-2026/__tests__/page.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import { redirect, notFound } from "next/navigation";
+import May30CloudPartyPage from "../page";
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn((url: string) => {
+    const error = new Error(`NEXT_REDIRECT: ${url}`);
+    (error as any).digest = `NEXT_REDIRECT;${url}`;
+    throw error;
+  }),
+  notFound: jest.fn(() => {
+    const error = new Error("NEXT_NOT_FOUND");
+    (error as any).digest = "NEXT_NOT_FOUND";
+    throw error;
+  }),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/api-client", () => ({
+  fetchPartyBySlug: jest.fn(),
+  fetchPartyRsvps: jest.fn(),
+}));
+
+jest.mock("next/headers", () => ({
+  headers: jest.fn(),
+}));
+
+jest.mock("../cloud-party-invitation", () => ({
+  CloudPartyInvitation: ({
+    party,
+    partyRsvps,
+    partyRsvpsError,
+    currentUserId,
+  }: any) => (
+    <div data-testid="cloud-party-invitation">
+      {party.name} / {party.slug} / {party.location} /{" "}
+      {partyRsvps?.length ?? 0} / {partyRsvpsError ?? "no-error"} /{" "}
+      {currentUserId}
+    </div>
+  ),
+}));
+
+describe("May30CloudPartyPage", () => {
+  const mockSession = {
+    user: {
+      id: "user-123",
+      email: "user@example.com",
+    },
+  };
+
+  const mockParty = {
+    party_id: "party-123",
+    name: "What's the Move?",
+    time: "2026-05-31T00:00:00Z",
+    location: "TBD",
+    description:
+      "A practical check-in on whether I should stay in New York or make a different move.",
+    slug: "whats-the-move-2026",
+    created_at: "2026-05-10T00:00:00Z",
+    updated_at: "2026-05-10T00:00:00Z",
+    deleted_at: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { auth } = require("@/lib/auth");
+    const { headers } = require("next/headers");
+
+    headers.mockResolvedValue(new Headers());
+    auth.api.getSession.mockResolvedValue(mockSession);
+  });
+
+  it("redirects to home when user is not authenticated", async () => {
+    const { auth } = require("@/lib/auth");
+    auth.api.getSession.mockResolvedValue(null);
+
+    await expect(May30CloudPartyPage()).rejects.toThrow("NEXT_REDIRECT");
+    expect(redirect).toHaveBeenCalledWith("/");
+  });
+
+  it("fetches the May 30 cloud party by slug and renders the invitation", async () => {
+    const { fetchPartyBySlug, fetchPartyRsvps } = require("@/lib/api-client");
+    fetchPartyBySlug.mockResolvedValue(mockParty);
+    fetchPartyRsvps.mockResolvedValue([{ rsvp_id: "rsvp-1" }]);
+
+    const component = await May30CloudPartyPage();
+    render(component);
+
+    expect(fetchPartyBySlug).toHaveBeenCalledWith("whats-the-move-2026");
+    expect(fetchPartyRsvps).toHaveBeenCalledWith("party-123");
+    expect(screen.getByTestId("cloud-party-invitation")).toHaveTextContent(
+      "What's the Move? / whats-the-move-2026 / TBD / 1 / no-error / user-123"
+    );
+  });
+
+  it("calls notFound when the party does not exist", async () => {
+    const { fetchPartyBySlug } = require("@/lib/api-client");
+    fetchPartyBySlug.mockResolvedValue(null);
+
+    await expect(May30CloudPartyPage()).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("renders an error state when party fetch fails", async () => {
+    const { fetchPartyBySlug } = require("@/lib/api-client");
+    fetchPartyBySlug.mockRejectedValue(new Error("Network error"));
+
+    const component = await May30CloudPartyPage();
+    render(component);
+
+    expect(screen.getByText("Error loading party")).toBeInTheDocument();
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+  });
+
+  it("passes RSVP fetch errors to the invitation", async () => {
+    const { fetchPartyBySlug, fetchPartyRsvps } = require("@/lib/api-client");
+    fetchPartyBySlug.mockResolvedValue(mockParty);
+    fetchPartyRsvps.mockRejectedValue(new Error("RSVP error"));
+
+    const component = await May30CloudPartyPage();
+    render(component);
+
+    expect(screen.getByTestId("cloud-party-invitation")).toHaveTextContent(
+      "What's the Move? / whats-the-move-2026 / TBD / 0 / RSVP error / user-123"
+    );
+  });
+});

--- a/app/bouncer/app/parties/whats-the-move-2026/cloud-party-invitation.tsx
+++ b/app/bouncer/app/parties/whats-the-move-2026/cloud-party-invitation.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import type { Party, RsvpWithUser } from "@/lib/types";
+import { LocalDateTime } from "@/app/components/local-date-time";
+import { AddressLink } from "@/app/components/address-link";
+import { CloudCanvas } from "@/lib/webgl/cloud-canvas";
+import { RsvpForm } from "../[slug]/rsvp-form";
+import { GuestList } from "../[slug]/guest-list";
+
+interface CloudPartyInvitationProps {
+  party: Party;
+  partyRsvps: RsvpWithUser[] | null;
+  partyRsvpsError: string | null;
+  currentUserId: string;
+}
+
+const previewWeather = {
+  temperature: "72°F",
+  condition: "partly cloudy",
+  wind: "SSW 8 mph",
+  sunset: "8:19 PM",
+};
+
+const dividerStyle = {
+  borderColor: "rgba(255, 255, 255, 0.18)",
+};
+
+export function CloudPartyInvitation({
+  party,
+  partyRsvps,
+  partyRsvpsError,
+  currentUserId,
+}: CloudPartyInvitationProps) {
+  return (
+    <div className="fixed inset-0 z-50 overflow-hidden bg-[#e7f7ff] text-slate-950">
+      <div className="pointer-events-none fixed inset-0 z-0">
+        <CloudCanvas className="h-full w-full" />
+      </div>
+
+      <div className="pointer-events-none fixed inset-x-0 top-0 z-[1] flex justify-between px-4 py-3 text-[11px] uppercase text-slate-700/70 md:px-6">
+        <span>may 30</span>
+        <span>
+          {previewWeather.temperature} / {previewWeather.condition}
+        </span>
+      </div>
+
+      <main
+        className="fixed inset-0 mx-auto flex min-h-screen w-full max-w-4xl flex-col overflow-y-auto px-4 pb-6 pt-14 md:px-6 md:pt-16"
+        style={{ zIndex: 20 }}
+      >
+        <div className="mb-2">
+          <Link
+            href="/invitations"
+            className="inline-flex text-[11px] uppercase text-slate-700 transition-colors hover:text-slate-950"
+          >
+            back
+          </Link>
+        </div>
+
+        <div className="grid gap-2 text-xs text-slate-800/88">
+          <section className="border-y py-2" style={dividerStyle}>
+            <div className="mb-2 flex items-center justify-between gap-3 uppercase text-slate-600/76">
+              <span>party</span>
+              <span>may 30</span>
+            </div>
+            <h1 className="text-[22px] leading-none text-slate-950 md:text-[33px]">
+              {party.name}
+            </h1>
+          </section>
+
+          <section
+            className="grid border-b py-2 md:grid-cols-[120px_1fr]"
+            style={dividerStyle}
+          >
+            <div className="uppercase text-slate-500">time</div>
+            <div>
+              <LocalDateTime dateTime={party.time} mode="date" />{" "}
+              <span className="text-slate-500">/</span>{" "}
+              <LocalDateTime dateTime={party.time} mode="time" />
+            </div>
+          </section>
+
+          <section
+            className="grid border-b py-2 md:grid-cols-[120px_1fr]"
+            style={dividerStyle}
+          >
+            <div className="uppercase text-slate-500">where</div>
+            <AddressLink location={party.location} />
+          </section>
+
+          <section
+            className="grid border-b py-2 md:grid-cols-[120px_1fr]"
+            style={dividerStyle}
+          >
+            <div className="uppercase text-slate-500">weather</div>
+            <div className="grid gap-1 md:grid-cols-4">
+              <div>{previewWeather.temperature}</div>
+              <div>{previewWeather.condition}</div>
+              <div>{previewWeather.wind}</div>
+              <div>sunset {previewWeather.sunset}</div>
+            </div>
+          </section>
+
+          {party.description && (
+            <section
+              className="grid border-b py-2 md:grid-cols-[120px_1fr]"
+              style={dividerStyle}
+            >
+              <div className="uppercase text-slate-500">note</div>
+              <p className="max-w-[68ch] leading-relaxed text-slate-800/88">
+                {party.description}
+              </p>
+            </section>
+          )}
+
+          <section
+            className="grid border-b py-2 md:grid-cols-[120px_1fr]"
+            style={dividerStyle}
+          >
+            <div className="uppercase text-slate-500">rsvp</div>
+            <div className="[&>div]:space-y-2 [&_.bg-black]:bg-slate-950 [&_.rounded]:rounded-none [&_.text-lg]:text-base">
+              <RsvpForm partyId={party.party_id} />
+            </div>
+          </section>
+
+          <section
+            className="grid border-b py-2 md:grid-cols-[120px_1fr]"
+            style={dividerStyle}
+          >
+            <div className="uppercase text-slate-500">guests</div>
+            <div className="[&_.rounded]:rounded-none [&_.text-xl]:text-base">
+              {partyRsvpsError && (
+                <div className="border border-red-200 bg-red-50 p-3 text-red-800">
+                  <p className="font-medium">Error loading guest list</p>
+                  <p className="text-sm">{partyRsvpsError}</p>
+                </div>
+              )}
+              {!partyRsvpsError && partyRsvps && (
+                <GuestList rsvps={partyRsvps} currentUserId={currentUserId} />
+              )}
+              {!partyRsvpsError && !partyRsvps && (
+                <div className="border p-3 text-slate-700" style={dividerStyle}>
+                  Loading guest list...
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/bouncer/app/parties/whats-the-move-2026/page.tsx
+++ b/app/bouncer/app/parties/whats-the-move-2026/page.tsx
@@ -1,0 +1,66 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { fetchPartyBySlug, fetchPartyRsvps } from "@/lib/api-client";
+import { CloudPartyInvitation } from "./cloud-party-invitation";
+
+export default async function May30CloudPartyPage() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    redirect("/");
+  }
+
+  let party;
+  let partyError: string | null = null;
+  try {
+    party = await fetchPartyBySlug("whats-the-move-2026");
+  } catch (error) {
+    partyError =
+      error instanceof Error ? error.message : "Failed to load party";
+  }
+
+  if (!party && !partyError) {
+    notFound();
+  }
+
+  if (partyError || !party) {
+    return (
+      <div className="p-4">
+        <div className="mb-6">
+          <Link
+            href="/invitations"
+            className="text-sm opacity-80 transition-opacity hover:opacity-100"
+          >
+            ← Back to invitations
+          </Link>
+        </div>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-red-800">
+          <p className="font-medium">Error loading party</p>
+          <p className="text-sm">{partyError || "Party not found"}</p>
+        </div>
+      </div>
+    );
+  }
+
+  let partyRsvps: Awaited<ReturnType<typeof fetchPartyRsvps>> | null = null;
+  let partyRsvpsError: string | null = null;
+  try {
+    partyRsvps = await fetchPartyRsvps(party.party_id);
+  } catch (error) {
+    partyRsvpsError =
+      error instanceof Error ? error.message : "Failed to load party RSVPs";
+  }
+
+  return (
+    <CloudPartyInvitation
+      party={party}
+      partyRsvps={partyRsvps}
+      partyRsvpsError={partyRsvpsError}
+      currentUserId={session.user.id}
+    />
+  );
+}

--- a/app/bouncer/lib/webgl/cloud-canvas.tsx
+++ b/app/bouncer/lib/webgl/cloud-canvas.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { OrthographicCamera } from "@react-three/drei";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Suspense, useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+
+interface CloudCanvasProps {
+  className?: string;
+  compact?: boolean;
+}
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position.xy, 0.0, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  precision highp float;
+
+  mat3 m = mat3(0.00, 0.80, 0.60, -0.80, 0.36, -0.48, -0.60, -0.48, 0.64);
+
+  uniform vec3 uCloudSize;
+  uniform vec3 uSunPosition;
+  uniform vec3 uCameraPosition;
+  uniform vec3 uCloudColor;
+  uniform vec3 uSkyColor;
+  uniform float uCloudSteps;
+  uniform float uShadowSteps;
+  uniform float uCloudLength;
+  uniform float uShadowLength;
+  uniform vec2 uResolution;
+  uniform float uTime;
+  uniform float uFocalLength;
+  uniform bool uRegress;
+
+  float hash(float n) {
+    return fract(sin(n) * 43758.5453);
+  }
+
+  float noise(vec3 x) {
+    vec3 p = floor(x);
+    vec3 f = fract(x);
+    f = f * f * (3.0 - 2.0 * f);
+
+    float n = p.x + p.y * 57.0 + 113.0 * p.z;
+    float res = mix(mix(mix(hash(n + 0.0), hash(n + 1.0), f.x),
+                        mix(hash(n + 57.0), hash(n + 58.0), f.x), f.y),
+                    mix(mix(hash(n + 113.0), hash(n + 114.0), f.x),
+                        mix(hash(n + 170.0), hash(n + 171.0), f.x), f.y), f.z);
+    return res;
+  }
+
+  float fbm(vec3 p) {
+    float f = 0.0;
+    f += 0.5000 * noise(p); p = m * p * 2.02;
+    f += 0.2500 * noise(p); p = m * p * 2.03;
+    f += 0.1250 * noise(p); p = m * p * 2.01;
+    f += 0.0625 * noise(p);
+    return f;
+  }
+
+  float cloudDepth(vec3 position) {
+    vec3 drift = vec3(uTime * 0.035, uTime * 0.014, -uTime * 0.018);
+    float ellipse = 1.0 - length(position * uCloudSize);
+    float cloud = ellipse + fbm(position * 1.08 + drift) * 1.82 - 0.46;
+
+    return min(max(0.0, cloud), 1.0);
+  }
+
+  vec4 cloudMarch(float jitter, vec3 position, vec3 ray) {
+    float stepLength = uCloudLength / uCloudSteps;
+    float shadowStepLength = uShadowLength / uShadowSteps;
+
+    vec3 lightDirection = normalize(uSunPosition);
+    vec3 cloudPosition = position + ray * jitter * stepLength;
+
+    vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
+
+    for (int i = 0; i < 64; i++) {
+      if (float(i) >= uCloudSteps || color.a < 0.1) break;
+
+      float depth = cloudDepth(cloudPosition);
+      if (depth > 0.001) {
+        vec3 lightPosition = cloudPosition + lightDirection * jitter * shadowStepLength;
+
+        float shadow = 0.0;
+        for (int s = 0; s < 16; s++) {
+          if (float(s) >= uShadowSteps) break;
+          lightPosition += lightDirection * shadowStepLength;
+          shadow += cloudDepth(lightPosition);
+        }
+        shadow = exp((-shadow / uShadowSteps) * 3.0);
+
+        float density = clamp((depth / uCloudSteps) * 22.0, 0.0, 1.0);
+        color.rgb += vec3(shadow * density) * uCloudColor * color.a;
+        color.a *= 1.0 - density;
+        color.rgb += density * uSkyColor * color.a;
+      }
+
+      cloudPosition += ray * stepLength;
+    }
+
+    return color;
+  }
+
+  mat3 lookAt(vec3 target, vec3 origin) {
+    vec3 cw = normalize(origin - target);
+    vec3 cu = normalize(cross(vec3(0.0, 1.0, 0.0), cw));
+    vec3 cv = normalize(cross(cw, cu));
+    return mat3(cu, cv, cw);
+  }
+
+  void main() {
+    vec2 pixel = (gl_FragCoord.xy * 2.0 - uResolution) / min(uResolution.x, uResolution.y);
+    float jitter = uRegress ? hash(pixel.x + pixel.y * 50.0 + uTime) : 0.0;
+
+    mat3 camera = lookAt(uCameraPosition, vec3(0.0, 0.82, 0.0));
+    vec3 ray = camera * normalize(vec3(pixel, uFocalLength));
+
+    vec4 color = cloudMarch(jitter, uCameraPosition, ray);
+    float horizon = smoothstep(-0.9, 0.9, pixel.y);
+    vec3 sky = mix(vec3(0.88, 0.96, 1.0), uSkyColor, horizon);
+    gl_FragColor = vec4(color.rgb + sky * color.a, 1.0);
+  }
+`;
+
+function CloudShader({ compact = false }: { compact?: boolean }) {
+  const materialRef = useRef<THREE.ShaderMaterial>(null);
+  const { size, gl, invalidate } = useThree();
+  const lastFrameTimeRef = useRef(0);
+  const uniforms = useMemo(
+    () => ({
+      uCloudSize: {
+        value: compact
+          ? new THREE.Vector3(0.76, 0.56, 0.76)
+          : new THREE.Vector3(0.5, 0.36, 0.5),
+      },
+      uSunPosition: { value: new THREE.Vector3(1.8, 2.4, 1.2) },
+      uCameraPosition: {
+        value: compact
+          ? new THREE.Vector3(0.0, 0.8, 2.3)
+          : new THREE.Vector3(0.0, 0.82, 2.72),
+      },
+      uCloudColor: { value: new THREE.Color("#ffffff") },
+      uSkyColor: { value: new THREE.Color(compact ? "#bdeaff" : "#a8ddff") },
+      uCloudSteps: { value: compact ? 32 : 42 },
+      uShadowSteps: { value: compact ? 5 : 7 },
+      uCloudLength: { value: compact ? 3.8 : 4.8 },
+      uShadowLength: { value: compact ? 1.25 : 1.65 },
+      uResolution: { value: new THREE.Vector2(size.width, size.height) },
+      uTime: { value: 0 },
+      uFocalLength: { value: compact ? -1.36 : -1.22 },
+      uRegress: { value: false },
+    }),
+    [compact, size.height, size.width]
+  );
+
+  useFrame((state) => {
+    if (!materialRef.current) return;
+    const elapsed = state.clock.elapsedTime;
+    if (elapsed - lastFrameTimeRef.current < 1 / 24) return;
+
+    lastFrameTimeRef.current = elapsed;
+    const dpr = gl.getPixelRatio();
+    materialRef.current.uniforms.uTime.value = elapsed;
+    materialRef.current.uniforms.uResolution.value.set(
+      size.width * dpr,
+      size.height * dpr
+    );
+  });
+
+  useEffect(() => {
+    const frameMs = 1000 / 24;
+    const interval = window.setInterval(() => {
+      invalidate();
+    }, frameMs);
+
+    return () => window.clearInterval(interval);
+  }, [invalidate]);
+
+  return (
+    <mesh>
+      <planeGeometry args={[2, 2]} />
+      <shaderMaterial
+        ref={materialRef}
+        uniforms={uniforms}
+        vertexShader={vertexShader}
+        fragmentShader={fragmentShader}
+        depthWrite={false}
+        depthTest={false}
+      />
+    </mesh>
+  );
+}
+
+export function CloudCanvas({
+  className = "",
+  compact = false,
+}: CloudCanvasProps) {
+  return (
+    <div className={`relative overflow-hidden ${className}`}>
+      <Canvas
+        className="absolute inset-0"
+        style={{ width: "100%", height: "100%", display: "block" }}
+        dpr={0.7}
+        frameloop="demand"
+        gl={{ alpha: false, antialias: false }}
+        resize={{ scroll: false, debounce: 0 }}
+      >
+        <Suspense fallback={null}>
+          <OrthographicCamera makeDefault position={[0, 0, 1]} />
+          <CloudShader compact={compact} />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}

--- a/app/bouncer/migrations/2026-05-10T20-00-00.may-30-cloud-party.sql
+++ b/app/bouncer/migrations/2026-05-10T20-00-00.may-30-cloud-party.sql
@@ -1,0 +1,22 @@
+INSERT INTO "party" (
+  "party_id",
+  "name",
+  "time",
+  "location",
+  "description",
+  "slug",
+  "created_at",
+  "updated_at",
+  "deleted_at"
+) VALUES (
+  '550e8400-e29b-41d4-a716-446655440010',
+  'What''s the Move?',
+  '2026-05-31T00:00:00Z'::timestamptz,
+  'TBD',
+  'A practical check-in on whether I should stay in New York or make a different move.',
+  'whats-the-move-2026',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP,
+  NULL
+)
+ON CONFLICT ("party_id") DO NOTHING;


### PR DESCRIPTION
## Summary
- add the bespoke `What's the Move?` party route at `/parties/whats-the-move-2026`
- connect the route to auth, party lookup, RSVP data, the real RSVP form, and the guest list
- add an optimized FBM volumetric cloud background with 24 FPS demand rendering and reduced DPR
- update invitation previews/highlights and seed data for the renamed party

## Testing
- `npm test -- --runTestsByPath app/parties/whats-the-move-2026/__tests__/page.test.tsx app/invitations/__tests__/page.test.tsx`

## Notes
- The configured database record has also been updated to `What's the Move?` with slug `whats-the-move-2026`.