### PR TITLE
[codex] Align invitation card sizing

### DIFF
--- a/app/bouncer/app/invitations/next-party-highlight.tsx
+++ b/app/bouncer/app/invitations/next-party-highlight.tsx
@@ -44,7 +44,7 @@ export function NextPartyHighlight({ party }: NextPartyHighlightProps) {
               <div className="relative z-10 flex h-full flex-col justify-between">
                 <div>
                   <h3
-                    className={`text-base md:text-lg font-semibold mb-3 transition-colors text-left leading-tight line-clamp-3 break-words ${
+                    className={`text-xl font-semibold mb-4 transition-colors text-left leading-tight line-clamp-3 break-words ${
                       hasCloudPreview
                         ? "text-black/90 hover:text-black"
                         : "text-black/90 hover:text-black"
@@ -53,7 +53,7 @@ export function NextPartyHighlight({ party }: NextPartyHighlightProps) {
                     {party.name}
                   </h3>
                   <p
-                    className={`text-xs text-left leading-relaxed ${
+                    className={`text-sm text-left leading-relaxed ${
                       hasCloudPreview ? "text-black/70" : "text-black/70"
                     }`}
                   >

--- a/app/bouncer/app/invitations/party-card.tsx
+++ b/app/bouncer/app/invitations/party-card.tsx
@@ -14,9 +14,9 @@ export function PartyCard({ party }: PartyCardProps) {
   const hasCloudPreview = party.slug === "whats-the-move-2026";
 
   return (
-    <div className="group w-[calc(50%-0.5rem)] md:w-auto">
+    <div className="group w-[clamp(180px,42vw,240px)] flex-shrink-0">
       <Link href={`/parties/${party.slug}`} className="block" prefetch={true}>
-        <div className="relative backdrop-blur-md rounded-lg p-6 border-2 border-black transition-all duration-300 group-hover:border-black cursor-pointer flex flex-col overflow-hidden aspect-[3/4] md:w-[240px] md:h-[320px]">
+        <div className="relative w-full backdrop-blur-md rounded-lg p-4 md:p-6 border-2 border-black transition-all duration-300 group-hover:border-black cursor-pointer flex flex-col overflow-hidden aspect-[3/4]">
           {/* Canvas preview for receipt-style invites */}
           {hasReceiptPreview && (
             <div className="absolute inset-0 rounded-lg overflow-hidden z-0 backdrop-blur-sm">


### PR DESCRIPTION
## Summary
- Make past invitation cards use the same clamped responsive width and 3:4 sizing contract as the next-party card
- Match next-party title and date typography to past-party cards

## Validation
- `npm test -- --runTestsByPath app/invitations/__tests__/page.test.tsx app/parties/whats-the-move-2026/__tests__/page.test.tsx --runInBand`
- `npx eslint app/invitations/party-card.tsx app/invitations/next-party-highlight.tsx`