### PR TITLE
Add guestbook notifications and RSVP summary

### DIFF
--- a/app/guestbook/Cargo.lock
+++ b/app/guestbook/Cargo.lock
@@ -79,10 +79,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -92,9 +120,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -130,6 +158,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -138,6 +168,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -194,10 +230,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -236,10 +301,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "fallible-iterator"
@@ -267,6 +349,21 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -321,14 +418,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -341,6 +453,8 @@ dependencies = [
  "dotenvy",
  "openssl",
  "postgres-openssl",
+ "reqwest",
+ "serde",
  "tokio",
  "tokio-postgres",
  "uuid",
@@ -359,6 +473,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -386,10 +597,184 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -419,6 +804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +823,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "md-5"
@@ -506,6 +903,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -628,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,10 +1058,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.42"
+name = "quinn"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -686,7 +1154,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -708,10 +1176,169 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "scopeguard"
@@ -720,12 +1347,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -746,6 +1403,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -775,10 +1445,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -795,6 +1487,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stringprep"
@@ -828,6 +1526,56 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -911,6 +1659,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1680,76 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -957,6 +1785,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,7 +1820,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -985,6 +1837,25 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1018,6 +1889,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1063,6 +1947,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1974,15 @@ dependencies = [
  "libredox",
  "wasite",
  "web-sys",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1134,11 +2046,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1152,20 +2073,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1175,9 +2118,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1187,9 +2142,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1199,15 +2166,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1220,6 +2205,35 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1240,3 +2254,69 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/app/guestbook/Cargo.toml
+++ b/app/guestbook/Cargo.toml
@@ -17,3 +17,5 @@ clap = { version = "4.5", features = ["derive"] }
 dotenvy = "0.15"
 uuid = { version = "1.11", features = ["v4", "serde"] }
 anyhow = "1.0"
+reqwest = { version = "0.13.3", default-features = false, features = ["rustls", "json"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/app/guestbook/src/main.rs
+++ b/app/guestbook/src/main.rs
@@ -3,6 +3,8 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use openssl::ssl::{SslConnector, SslMethod};
 use postgres_openssl::MakeTlsConnector;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
 use tokio_postgres::Client;
 use uuid::Uuid;
 
@@ -52,6 +54,12 @@ enum Commands {
         slug: String,
     },
 
+    /// Show RSVP summary for a party
+    Summary {
+        /// Slug of the party
+        slug: String,
+    },
+
     /// Update a party
     Update {
         /// Slug of the party to update
@@ -86,6 +94,20 @@ enum Commands {
         slug: String,
     },
 
+    /// Send a new-party notification email to all verified users
+    Notify {
+        /// Slug of the party to notify guests about
+        slug: String,
+
+        /// Explicit recipient email. May be repeated or comma-separated.
+        #[arg(long = "email", value_delimiter = ',')]
+        emails: Vec<String>,
+
+        /// Preview recipients and email content without sending via Resend
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Create the party table with the schema from RFD-006
     CreateTable,
 
@@ -98,7 +120,7 @@ enum Commands {
 }
 
 async fn connect_db() -> Result<Client> {
-    dotenvy::dotenv().ok();
+    load_environment();
 
     let connection_string = std::env::var("NEON_POSTGRES_URL")
         .context("NEON_POSTGRES_URL environment variable not set")?;
@@ -116,6 +138,37 @@ async fn connect_db() -> Result<Client> {
     });
 
     Ok(client)
+}
+
+fn find_env_file_from(start: &Path, filename: &str) -> Option<PathBuf> {
+    let mut directory = start.to_path_buf();
+
+    loop {
+        let candidate = directory.join(filename);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+
+        if !directory.pop() {
+            return None;
+        }
+    }
+}
+
+fn find_env_file(filename: &str) -> Option<PathBuf> {
+    std::env::current_dir()
+        .ok()
+        .and_then(|current_dir| find_env_file_from(&current_dir, filename))
+}
+
+fn load_environment() {
+    if let Some(env_path) = find_env_file(".env") {
+        dotenvy::from_path(env_path).ok();
+    }
+
+    if let Some(env_local_path) = find_env_file(".env.local") {
+        dotenvy::from_path_override(env_local_path).ok();
+    }
 }
 
 async fn create_party(
@@ -227,6 +280,185 @@ async fn get_party(client: &Client, slug: String) -> Result<()> {
         println!("Deleted:     {}", deleted.format("%Y-%m-%d %H:%M:%S %Z"));
     }
     println!("{}\n", "=".repeat(80));
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct PartySummary {
+    party_id: String,
+    name: String,
+    slug: String,
+    time: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+struct RsvpSummaryRow {
+    name: Option<String>,
+    email: String,
+    status: String,
+    updated_at: Option<DateTime<Utc>>,
+}
+
+fn rsvp_status_label(status: &str) -> &'static str {
+    match status {
+        "accepted" => "Going",
+        "pending" => "Maybe",
+        "declined" => "Declined",
+        "not_started" => "Not started",
+        _ => "Other",
+    }
+}
+
+fn rsvp_status_order(status: &str) -> usize {
+    match status {
+        "accepted" => 0,
+        "pending" => 1,
+        "declined" => 2,
+        "not_started" => 3,
+        _ => 4,
+    }
+}
+
+fn count_rsvp_status(rows: &[RsvpSummaryRow], status: &str) -> usize {
+    rows.iter().filter(|row| row.status == status).count()
+}
+
+fn format_rsvp_summary_person(row: &RsvpSummaryRow) -> String {
+    let display_name = row.name.as_deref().unwrap_or("").trim();
+    let person = if display_name.is_empty() {
+        row.email.clone()
+    } else {
+        format!("{} <{}>", display_name, row.email)
+    };
+
+    match row.updated_at {
+        Some(updated_at) => format!(
+            "{} (updated {})",
+            person,
+            updated_at.format("%Y-%m-%d %H:%M")
+        ),
+        None => person,
+    }
+}
+
+async fn fetch_party_summary(client: &Client, slug: &str) -> Result<Option<PartySummary>> {
+    let row = client
+        .query_opt(
+            "SELECT party_id, name, slug, time
+             FROM party
+             WHERE slug = $1 AND deleted_at IS NULL",
+            &[&slug],
+        )
+        .await?;
+
+    row.map(|row| -> Result<PartySummary, tokio_postgres::Error> {
+        Ok(PartySummary {
+            party_id: row.try_get("party_id")?,
+            name: row.try_get("name")?,
+            slug: row.try_get("slug")?,
+            time: row.try_get("time")?,
+        })
+    })
+    .transpose()
+    .context("Failed to parse party summary row")
+}
+
+async fn fetch_rsvp_summary_rows(client: &Client, party_id: &str) -> Result<Vec<RsvpSummaryRow>> {
+    let rows = client
+        .query(
+            r#"
+            SELECT
+                u.name,
+                u.email,
+                COALESCE(r.status, 'not_started') AS status,
+                r.updated_at
+            FROM "user" u
+            LEFT JOIN rsvp r
+                ON r.user_id = u.id
+                AND r.party_id = $1
+                AND r.deleted_at IS NULL
+            WHERE btrim(u.email) <> ''
+            ORDER BY
+                CASE COALESCE(r.status, 'not_started')
+                    WHEN 'accepted' THEN 0
+                    WHEN 'pending' THEN 1
+                    WHEN 'declined' THEN 2
+                    WHEN 'not_started' THEN 3
+                    ELSE 4
+                END,
+                lower(COALESCE(NULLIF(btrim(u.name), ''), u.email)),
+                lower(u.email)
+            "#,
+            &[&party_id],
+        )
+        .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(RsvpSummaryRow {
+                name: row.try_get("name")?,
+                email: row.try_get("email")?,
+                status: row.try_get("status")?,
+                updated_at: row.try_get("updated_at")?,
+            })
+        })
+        .collect::<Result<Vec<_>, tokio_postgres::Error>>()
+        .context("Failed to parse RSVP summary rows")
+}
+
+fn print_rsvp_summary(party: &PartySummary, rows: &[RsvpSummaryRow]) {
+    println!("\nRSVP summary: {}", party.name);
+    println!("{}", "=".repeat(80));
+    println!("Slug: {}", party.slug);
+    println!("Time: {}", party.time.format("%Y-%m-%d %H:%M:%S %Z"));
+    println!("Total users: {}", rows.len());
+    println!("Going: {}", count_rsvp_status(rows, "accepted"));
+    println!("Maybe: {}", count_rsvp_status(rows, "pending"));
+    println!("Declined: {}", count_rsvp_status(rows, "declined"));
+    println!("Not started: {}", count_rsvp_status(rows, "not_started"));
+
+    for status in ["accepted", "pending", "declined", "not_started"] {
+        let people = rows
+            .iter()
+            .filter(|row| row.status == status)
+            .collect::<Vec<_>>();
+
+        if people.is_empty() {
+            continue;
+        }
+
+        println!("\n{} ({})", rsvp_status_label(status), people.len());
+        for person in people {
+            println!("  - {}", format_rsvp_summary_person(person));
+        }
+    }
+
+    let other_statuses = rows
+        .iter()
+        .filter(|row| rsvp_status_order(&row.status) == 4)
+        .collect::<Vec<_>>();
+    if !other_statuses.is_empty() {
+        println!("\nOther ({})", other_statuses.len());
+        for person in other_statuses {
+            println!(
+                "  - {} [{}]",
+                format_rsvp_summary_person(person),
+                person.status
+            );
+        }
+    }
+
+    println!("\n{}", "=".repeat(80));
+}
+
+async fn show_rsvp_summary(client: &Client, slug: String) -> Result<()> {
+    let party = fetch_party_summary(client, &slug)
+        .await?
+        .with_context(|| format!("Party with slug '{}' not found or already deleted", slug))?;
+    let rows = fetch_rsvp_summary_rows(client, &party.party_id).await?;
+
+    print_rsvp_summary(&party, &rows);
 
     Ok(())
 }
@@ -457,10 +689,585 @@ async fn clear_table(client: &Client, confirm: String) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone)]
+struct PartyNotification {
+    name: String,
+    slug: String,
+    time: DateTime<Utc>,
+    location: String,
+    description: String,
+}
+
+#[derive(Debug, Clone)]
+struct PartyNotificationEmail {
+    subject: String,
+    html: String,
+    text: String,
+    rsvp_url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ResendEmailPayload {
+    from: String,
+    to: String,
+    subject: String,
+    html: String,
+    text: String,
+}
+
+#[derive(Debug)]
+struct SendFailure {
+    email: String,
+    error: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NotificationConfig {
+    resend_api_key: Option<String>,
+    from_email: Option<String>,
+    site_base_url: String,
+}
+
+fn load_notification_config(dry_run: bool) -> Result<NotificationConfig> {
+    let site_base_url = std::env::var("PARTY_SITE_BASE_URL")
+        .context("PARTY_SITE_BASE_URL environment variable is required for notifications")?;
+
+    if dry_run {
+        return Ok(NotificationConfig {
+            resend_api_key: None,
+            from_email: None,
+            site_base_url,
+        });
+    }
+
+    Ok(NotificationConfig {
+        resend_api_key: Some(
+            std::env::var("RESEND_API_KEY")
+                .context("RESEND_API_KEY environment variable is required for notifications")?,
+        ),
+        from_email: Some(
+            std::env::var("RESEND_FROM_EMAIL")
+                .context("RESEND_FROM_EMAIL environment variable is required for notifications")?,
+        ),
+        site_base_url,
+    })
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn build_party_notification_email(
+    party: &PartyNotification,
+    site_base_url: &str,
+) -> PartyNotificationEmail {
+    let base_url = site_base_url.trim_end_matches('/');
+    let rsvp_url = format!("{}/parties/{}", base_url, party.slug);
+    let formatted_time = party.time.format("%A, %B %-d, %Y at %-I:%M %p UTC");
+    let subject = format!("Sanjay invited you to {}", party.name);
+
+    let html = format!(
+        r#"
+<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; color: #222; line-height: 1.5;">
+  <p>Hey,</p>
+  <p>I am hosting {name} and wanted to invite you.</p>
+  <p>
+    When: {time}<br>
+    Where: {location}
+  </p>
+  <p>{description}</p>
+  <p>RSVP here:<br><a href="{rsvp_url}">{rsvp_url}</a></p>
+  <p style="color: #666; font-size: 14px;">
+    You are getting this because you have an account on sanjay.party.
+    Reply here with any questions. If you do not want party invites, reply "unsubscribe".
+  </p>
+</div>
+"#,
+        name = escape_html(&party.name),
+        description = escape_html(&party.description),
+        time = escape_html(&formatted_time.to_string()),
+        location = escape_html(&party.location),
+        rsvp_url = escape_html(&rsvp_url),
+    );
+
+    let text = format!(
+        "Hey,\n\nI am hosting {} and wanted to invite you.\n\nWhen: {}\nWhere: {}\n\n{}\n\nRSVP here:\n{}\n\nYou are getting this because you have an account on sanjay.party.\nReply here with any questions. If you do not want party invites, reply \"unsubscribe\".",
+        party.name, formatted_time, party.location, party.description, rsvp_url
+    );
+
+    PartyNotificationEmail {
+        subject,
+        html,
+        text,
+        rsvp_url,
+    }
+}
+
+fn build_resend_payload(
+    from_email: &str,
+    recipient_email: &str,
+    email: &PartyNotificationEmail,
+) -> ResendEmailPayload {
+    ResendEmailPayload {
+        from: from_email.to_string(),
+        to: recipient_email.to_string(),
+        subject: email.subject.clone(),
+        html: email.html.clone(),
+        text: email.text.clone(),
+    }
+}
+
+fn normalize_explicit_recipient_emails(emails: Vec<String>) -> Vec<String> {
+    let mut recipients = Vec::new();
+
+    for email in emails {
+        let email = email.trim();
+        if email.is_empty() || recipients.iter().any(|existing| existing == email) {
+            continue;
+        }
+
+        recipients.push(email.to_string());
+    }
+
+    recipients
+}
+
+async fn fetch_party_notification(
+    client: &Client,
+    slug: &str,
+) -> Result<Option<PartyNotification>> {
+    let row = client
+        .query_opt(
+            "SELECT name, slug, time, location, description
+             FROM party
+             WHERE slug = $1 AND deleted_at IS NULL",
+            &[&slug],
+        )
+        .await?;
+
+    row.map(|row| -> Result<PartyNotification, tokio_postgres::Error> {
+        Ok(PartyNotification {
+            name: row.try_get("name")?,
+            slug: row.try_get("slug")?,
+            time: row.try_get("time")?,
+            location: row.try_get("location")?,
+            description: row.try_get("description")?,
+        })
+    })
+    .transpose()
+    .context("Failed to parse party notification row")
+}
+
+async fn fetch_verified_recipient_emails(client: &Client) -> Result<Vec<String>> {
+    let rows = client
+        .query(
+            r#"
+            SELECT email
+            FROM "user"
+            WHERE "emailVerified" = true
+              AND btrim(email) <> ''
+            ORDER BY email ASC
+            "#,
+            &[],
+        )
+        .await?;
+
+    rows.into_iter()
+        .map(|row| row.try_get("email").context("Failed to parse user email"))
+        .collect()
+}
+
+async fn send_resend_email(
+    http_client: &reqwest::Client,
+    api_key: &str,
+    payload: &ResendEmailPayload,
+) -> Result<()> {
+    send_resend_email_to_endpoint(
+        http_client,
+        api_key,
+        "https://api.resend.com/emails",
+        payload,
+    )
+    .await
+}
+
+async fn send_resend_email_to_endpoint(
+    http_client: &reqwest::Client,
+    api_key: &str,
+    endpoint: &str,
+    payload: &ResendEmailPayload,
+) -> Result<()> {
+    let response = http_client
+        .post(endpoint)
+        .bearer_auth(api_key)
+        .json(payload)
+        .send()
+        .await
+        .context("Failed to send request to Resend")?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unable to read response body".to_string());
+        anyhow::bail!("Resend returned {}: {}", status, body);
+    }
+
+    Ok(())
+}
+
+async fn notify_party(
+    client: &Client,
+    slug: String,
+    explicit_recipient_emails: Vec<String>,
+    dry_run: bool,
+) -> Result<()> {
+    let config = load_notification_config(dry_run)?;
+
+    let party = fetch_party_notification(client, &slug)
+        .await?
+        .with_context(|| format!("Party with slug '{}' not found or already deleted", slug))?;
+    let explicit_recipients = normalize_explicit_recipient_emails(explicit_recipient_emails);
+    let (recipients, recipient_label) = if explicit_recipients.is_empty() {
+        (
+            fetch_verified_recipient_emails(client).await?,
+            "verified users",
+        )
+    } else {
+        (explicit_recipients, "explicit recipients")
+    };
+
+    if recipients.is_empty() {
+        anyhow::bail!("No recipient email addresses found");
+    }
+
+    let email = build_party_notification_email(&party, &config.site_base_url);
+
+    if dry_run {
+        println!(
+            "Dry run: would send party notification for '{}' to {} {}",
+            party.name,
+            recipients.len(),
+            recipient_label
+        );
+        println!("  Subject: {}", email.subject);
+        println!("  RSVP link: {}", email.rsvp_url);
+        println!("\nRecipients:");
+        for recipient in &recipients {
+            println!("  - {}", recipient);
+        }
+        println!("\nPlain-text preview:\n{}", email.text);
+        return Ok(());
+    }
+
+    let resend_api_key = config
+        .resend_api_key
+        .as_deref()
+        .expect("RESEND_API_KEY is loaded when dry_run is false");
+    let from_email = config
+        .from_email
+        .as_deref()
+        .expect("RESEND_FROM_EMAIL is loaded when dry_run is false");
+    let http_client = reqwest::Client::new();
+    let mut sent_count = 0usize;
+    let mut failures = Vec::new();
+
+    println!(
+        "Sending party notification for '{}' to {} {}",
+        party.name,
+        recipients.len(),
+        recipient_label
+    );
+
+    for recipient in &recipients {
+        let payload = build_resend_payload(&from_email, recipient, &email);
+        match send_resend_email(&http_client, &resend_api_key, &payload).await {
+            Ok(()) => {
+                sent_count += 1;
+                println!("✓ Sent notification to {}", recipient);
+            }
+            Err(error) => {
+                eprintln!("✗ Failed to send notification to {}: {}", recipient, error);
+                failures.push(SendFailure {
+                    email: recipient.clone(),
+                    error: error.to_string(),
+                });
+            }
+        }
+    }
+
+    println!("\nNotification summary");
+    println!("  Total recipients: {}", recipients.len());
+    println!("  Sent: {}", sent_count);
+    println!("  Failed: {}", failures.len());
+    println!("  RSVP link: {}", email.rsvp_url);
+
+    if !failures.is_empty() {
+        println!("\nFailed recipients:");
+        for failure in &failures {
+            println!("  - {} ({})", failure.email, failure.error);
+        }
+    }
+
+    if sent_count == 0 {
+        anyhow::bail!("Failed to send all {} notifications", recipients.len());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn test_party() -> PartyNotification {
+        PartyNotification {
+            name: "Sanjay's <Party>".to_string(),
+            slug: "new-party".to_string(),
+            time: "2026-05-31T00:00:00Z".parse().unwrap(),
+            location: "Austin & <NYC>".to_string(),
+            description: "Bring \"ideas\" & snacks.".to_string(),
+        }
+    }
+
+    #[test]
+    fn finds_env_file_in_parent_directory() {
+        let temp_root = std::env::temp_dir().join(format!("guestbook-env-test-{}", Uuid::new_v4()));
+        let nested_dir = temp_root.join("app").join("guestbook");
+        fs::create_dir_all(&nested_dir).unwrap();
+        fs::write(
+            temp_root.join(".env.local"),
+            "PARTY_SITE_BASE_URL=https://example.com",
+        )
+        .unwrap();
+
+        let found = find_env_file_from(&nested_dir, ".env.local");
+
+        assert_eq!(found, Some(temp_root.join(".env.local")));
+
+        fs::remove_dir_all(temp_root).unwrap();
+    }
+
+    #[test]
+    fn builds_party_notification_email_with_escaped_html_and_plain_text() {
+        let party = test_party();
+        let email = build_party_notification_email(&party, "https://sanjay.party");
+
+        assert_eq!(email.subject, "Sanjay invited you to Sanjay's <Party>");
+        assert_eq!(email.rsvp_url, "https://sanjay.party/parties/new-party");
+        assert!(email.html.contains("Sanjay&#39;s &lt;Party&gt;"));
+        assert!(email.html.contains("Austin &amp; &lt;NYC&gt;"));
+        assert!(email.html.contains("Bring &quot;ideas&quot; &amp; snacks."));
+        assert!(!email.html.contains("Sanjay's <Party>"));
+        assert!(email.text.contains("Sanjay's <Party>"));
+        assert!(email
+            .text
+            .contains("RSVP here:\nhttps://sanjay.party/parties/new-party"));
+        assert!(email
+            .text
+            .contains("You are getting this because you have an account on sanjay.party."));
+        assert!(email.text.contains("reply \"unsubscribe\""));
+        assert!(!email.html.contains("View invitation and RSVP"));
+    }
+
+    #[test]
+    fn trims_base_url_before_building_rsvp_link() {
+        let party = test_party();
+        let email = build_party_notification_email(&party, "https://sanjay.party/");
+
+        assert_eq!(email.rsvp_url, "https://sanjay.party/parties/new-party");
+    }
+
+    #[test]
+    fn builds_resend_payload() {
+        let email = PartyNotificationEmail {
+            subject: "You're invited: Test".to_string(),
+            html: "<p>Hello</p>".to_string(),
+            text: "Hello".to_string(),
+            rsvp_url: "https://sanjay.party/parties/test".to_string(),
+        };
+
+        let payload =
+            build_resend_payload("Party <party@sanjay.party>", "guest@example.com", &email);
+
+        assert_eq!(payload.from, "Party <party@sanjay.party>");
+        assert_eq!(payload.to, "guest@example.com");
+        assert_eq!(payload.subject, "You're invited: Test");
+        assert_eq!(payload.html, "<p>Hello</p>");
+        assert_eq!(payload.text, "Hello");
+    }
+
+    #[test]
+    fn formats_rsvp_summary_people_with_and_without_names() {
+        let updated_at: DateTime<Utc> = "2026-05-31T00:00:00Z".parse().unwrap();
+        let named = RsvpSummaryRow {
+            name: Some("  Jane Guest  ".to_string()),
+            email: "jane@example.com".to_string(),
+            status: "accepted".to_string(),
+            updated_at: Some(updated_at),
+        };
+        let unnamed = RsvpSummaryRow {
+            name: Some(" ".to_string()),
+            email: "anon@example.com".to_string(),
+            status: "not_started".to_string(),
+            updated_at: None,
+        };
+
+        assert_eq!(
+            format_rsvp_summary_person(&named),
+            "Jane Guest <jane@example.com> (updated 2026-05-31 00:00)"
+        );
+        assert_eq!(format_rsvp_summary_person(&unnamed), "anon@example.com");
+    }
+
+    #[test]
+    fn counts_rsvp_summary_statuses() {
+        let rows = vec![
+            RsvpSummaryRow {
+                name: None,
+                email: "a@example.com".to_string(),
+                status: "accepted".to_string(),
+                updated_at: None,
+            },
+            RsvpSummaryRow {
+                name: None,
+                email: "b@example.com".to_string(),
+                status: "accepted".to_string(),
+                updated_at: None,
+            },
+            RsvpSummaryRow {
+                name: None,
+                email: "c@example.com".to_string(),
+                status: "pending".to_string(),
+                updated_at: None,
+            },
+        ];
+
+        assert_eq!(count_rsvp_status(&rows, "accepted"), 2);
+        assert_eq!(count_rsvp_status(&rows, "pending"), 1);
+        assert_eq!(count_rsvp_status(&rows, "declined"), 0);
+        assert_eq!(rsvp_status_label("not_started"), "Not started");
+        assert_eq!(rsvp_status_order("accepted"), 0);
+        assert_eq!(rsvp_status_order("unknown"), 4);
+    }
+
+    #[test]
+    fn normalizes_explicit_recipient_emails() {
+        let recipients = normalize_explicit_recipient_emails(vec![
+            " guest@example.com ".to_string(),
+            "".to_string(),
+            "guest@example.com".to_string(),
+            "friend@example.com".to_string(),
+        ]);
+
+        assert_eq!(
+            recipients,
+            vec![
+                "guest@example.com".to_string(),
+                "friend@example.com".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn dry_run_config_does_not_require_resend_credentials() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("PARTY_SITE_BASE_URL", "https://sanjay.party");
+        std::env::remove_var("RESEND_API_KEY");
+        std::env::remove_var("RESEND_FROM_EMAIL");
+
+        let config = load_notification_config(true).unwrap();
+
+        assert_eq!(
+            config,
+            NotificationConfig {
+                resend_api_key: None,
+                from_email: None,
+                site_base_url: "https://sanjay.party".to_string(),
+            }
+        );
+
+        std::env::remove_var("PARTY_SITE_BASE_URL");
+    }
+
+    #[test]
+    fn send_config_requires_resend_credentials() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("PARTY_SITE_BASE_URL", "https://sanjay.party");
+        std::env::remove_var("RESEND_API_KEY");
+        std::env::remove_var("RESEND_FROM_EMAIL");
+
+        let error = load_notification_config(false).unwrap_err();
+
+        assert!(error.to_string().contains("RESEND_API_KEY"));
+
+        std::env::remove_var("PARTY_SITE_BASE_URL");
+    }
+
+    #[tokio::test]
+    async fn sends_resend_payload_to_http_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = vec![0; 4096];
+            let bytes_read = stream.read(&mut buffer).await.unwrap();
+            let request = String::from_utf8_lossy(&buffer[..bytes_read]).to_string();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\n\r\n{\"id\":\"ok\"}",
+                )
+                .await
+                .unwrap();
+            request
+        });
+
+        let email = PartyNotificationEmail {
+            subject: "You're invited: Test".to_string(),
+            html: "<p>Hello</p>".to_string(),
+            text: "Hello".to_string(),
+            rsvp_url: "https://sanjay.party/parties/test".to_string(),
+        };
+        let payload =
+            build_resend_payload("Party <party@sanjay.party>", "guest@example.com", &email);
+        let http_client = reqwest::Client::new();
+
+        send_resend_email_to_endpoint(
+            &http_client,
+            "test-api-key",
+            &format!("http://{}/emails", address),
+            &payload,
+        )
+        .await
+        .unwrap();
+
+        let request = server.await.unwrap();
+        assert!(request.starts_with("POST /emails HTTP/1.1"));
+        assert!(request.contains("authorization: Bearer test-api-key"));
+        assert!(request.contains("\"from\":\"Party <party@sanjay.party>\""));
+        assert!(request.contains("\"to\":\"guest@example.com\""));
+        assert!(request.contains("\"subject\":\"You're invited: Test\""));
+        assert!(request.contains("\"html\":\"<p>Hello</p>\""));
+        assert!(request.contains("\"text\":\"Hello\""));
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Load environment variables from .env file
-    dotenvy::dotenv().ok();
+    load_environment();
 
     let cli = Cli::parse();
     let client = connect_db().await?;
@@ -478,6 +1285,8 @@ async fn main() -> Result<()> {
 
         Commands::Get { slug } => get_party(&client, slug).await?,
 
+        Commands::Summary { slug } => show_rsvp_summary(&client, slug).await?,
+
         Commands::Update {
             slug,
             name,
@@ -489,6 +1298,12 @@ async fn main() -> Result<()> {
         Commands::Delete { slug } => delete_party(&client, slug).await?,
 
         Commands::Purge { slug } => purge_party(&client, slug).await?,
+
+        Commands::Notify {
+            slug,
+            emails,
+            dry_run,
+        } => notify_party(&client, slug, emails, dry_run).await?,
 
         Commands::CreateTable => create_table(&client).await?,
 


### PR DESCRIPTION
## Summary
- Add `guestbook notify` for Resend-powered party email notifications
- Support dry runs and explicit recipient lists for notification sends
- Load root `.env.local` values for the guestbook CLI
- Add `guestbook summary` to view RSVP counts and grouped attendee status

## Verification
- `cargo check` in `app/guestbook`
- `cargo test` in `app/guestbook`
- Smoke-tested `guestbook summary whats-the-move-2026` against the live database