### PR TITLE
[codex] Show maybe guests in guest list

### DIFF
--- a/app/bouncer/app/parties/[slug]/__tests__/guest-list.test.tsx
+++ b/app/bouncer/app/parties/[slug]/__tests__/guest-list.test.tsx
@@ -85,12 +85,13 @@ describe("GuestList", () => {
     expect(screen.getByText("Jane Smith")).toBeInTheDocument();
   });
 
-  it("filters out pending RSVPs", () => {
+  it("displays pending RSVPs with a maybe label", () => {
     const rsvps = [mockRsvpWithUser1, mockRsvpPending];
     render(<GuestList rsvps={rsvps} currentUserId={currentUserId} />);
 
     expect(screen.getByText("John Doe")).toBeInTheDocument();
-    expect(screen.queryByText("Bob Pending")).not.toBeInTheDocument();
+    expect(screen.getByText("Bob Pending")).toBeInTheDocument();
+    expect(screen.getByText("Maybe")).toBeInTheDocument();
   });
 
   it("filters out declined RSVPs", () => {
@@ -117,13 +118,13 @@ describe("GuestList", () => {
     // Should not display anything for the null name RSVP
   });
 
-  it("displays empty state when no accepted guests", () => {
-    const rsvps = [mockRsvpPending, mockRsvpDeclined];
+  it("displays empty state when no accepted or pending guests", () => {
+    const rsvps = [mockRsvpDeclined];
     render(<GuestList rsvps={rsvps} currentUserId={currentUserId} />);
 
     expect(screen.getByText("Guests")).toBeInTheDocument();
     expect(
-      screen.getByText("No guests have accepted yet.")
+      screen.getByText("No guests have responded yet.")
     ).toBeInTheDocument();
   });
 
@@ -132,7 +133,7 @@ describe("GuestList", () => {
 
     expect(screen.getByText("Guests")).toBeInTheDocument();
     expect(
-      screen.getByText("No guests have accepted yet.")
+      screen.getByText("No guests have responded yet.")
     ).toBeInTheDocument();
   });
 
@@ -142,7 +143,7 @@ describe("GuestList", () => {
 
     expect(screen.getByText("Guests")).toBeInTheDocument();
     expect(
-      screen.getByText("No guests have accepted yet.")
+      screen.getByText("No guests have responded yet.")
     ).toBeInTheDocument();
   });
 
@@ -174,10 +175,11 @@ describe("GuestList", () => {
     ];
     render(<GuestList rsvps={rsvps} currentUserId={currentUserId} />);
 
-    // Should only show accepted guests that are not the current user
+    // Should show accepted and pending guests that are not the current user
     expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("Bob Pending")).toBeInTheDocument();
+    expect(screen.getByText("Maybe")).toBeInTheDocument();
     expect(screen.getByText("Jane Smith")).toBeInTheDocument();
-    expect(screen.queryByText("Bob Pending")).not.toBeInTheDocument();
     expect(screen.queryByText("Alice Declined")).not.toBeInTheDocument();
     expect(screen.queryByText("Current User")).not.toBeInTheDocument();
   });

--- a/app/bouncer/app/parties/[slug]/guest-list.tsx
+++ b/app/bouncer/app/parties/[slug]/guest-list.tsx
@@ -6,20 +6,19 @@ interface GuestListProps {
 }
 
 export function GuestList({ rsvps, currentUserId }: GuestListProps) {
-  // Filter to only accepted RSVPs with names, excluding the current user
-  const acceptedGuests = rsvps.filter(
+  const visibleGuests = rsvps.filter(
     (rsvp) =>
-      rsvp.status === "accepted" &&
+      (rsvp.status === "accepted" || rsvp.status === "pending") &&
       rsvp.user_name !== null &&
       rsvp.user_name !== undefined &&
       rsvp.user_id !== currentUserId
   );
 
-  if (acceptedGuests.length === 0) {
+  if (visibleGuests.length === 0) {
     return (
       <div className="p-4 bg-white/5 rounded border border-white/10">
         <h3 className="text-xl mb-4">Guests</h3>
-        <p className="text-sm opacity-80">No guests have accepted yet.</p>
+        <p className="text-sm opacity-80">No guests have responded yet.</p>
       </div>
     );
   }
@@ -28,9 +27,14 @@ export function GuestList({ rsvps, currentUserId }: GuestListProps) {
     <div className="p-4 bg-white/5 rounded border border-white/10">
       <h3 className="text-xl mb-4">Guests</h3>
       <ul className="space-y-2">
-        {acceptedGuests.map((rsvp) => (
-          <li key={rsvp.rsvp_id} className="text-base">
-            {rsvp.user_name}
+        {visibleGuests.map((rsvp) => (
+          <li key={rsvp.rsvp_id} className="flex items-center gap-2 text-base">
+            <span>{rsvp.user_name}</span>
+            {rsvp.status === "pending" ? (
+              <span className="rounded border border-yellow-600/30 px-2 py-0.5 text-xs font-medium text-yellow-700">
+                Maybe
+              </span>
+            ) : null}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- Include `pending` RSVPs in the guest list alongside accepted guests
- Add a small `Maybe` label for pending guests
- Update guest list tests and empty-state copy for accepted-or-pending visibility

## Validation
- `npm test -- --runTestsByPath 'app/parties/[slug]/__tests__/guest-list.test.tsx'`
- `npm test -- --runInBand`

Note: Jest emits existing unrelated console warnings/logs in auth/email tests and a stale `baseline-browser-mapping` warning, but all tests pass.