### PR TITLE
[codex] Preserve line breaks on whats-the-move

### DIFF
--- a/app/bouncer/app/parties/whats-the-move-2026/__tests__/cloud-party-invitation.test.tsx
+++ b/app/bouncer/app/parties/whats-the-move-2026/__tests__/cloud-party-invitation.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { CloudPartyInvitation } from "../cloud-party-invitation";
+
+jest.mock("@/lib/webgl/cloud-canvas", () => ({
+  CloudCanvas: () => <div data-testid="cloud-canvas" />,
+}));
+
+jest.mock("../../[slug]/rsvp-form", () => ({
+  RsvpForm: () => <div data-testid="rsvp-form" />,
+}));
+
+jest.mock("../../[slug]/guest-list", () => ({
+  GuestList: () => <div data-testid="guest-list" />,
+}));
+
+jest.mock("@/app/components/local-date-time", () => ({
+  LocalDateTime: ({ mode }: { mode: string }) => <span>{mode}</span>,
+}));
+
+jest.mock("@/app/components/address-link", () => ({
+  AddressLink: ({ location }: { location: string }) => <span>{location}</span>,
+}));
+
+describe("CloudPartyInvitation", () => {
+  it("preserves line breaks in the party description", () => {
+    render(
+      <CloudPartyInvitation
+        party={{
+          party_id: "party-123",
+          name: "What's the Move?",
+          time: "2026-05-31T00:00:00Z",
+          location: "TBD",
+          description: "First line\nSecond line",
+          slug: "whats-the-move-2026",
+          created_at: "2026-05-10T00:00:00Z",
+          updated_at: "2026-05-10T00:00:00Z",
+          deleted_at: null,
+        }}
+        partyRsvps={[]}
+        partyRsvpsError={null}
+        currentUserId="user-123"
+      />
+    );
+
+    const description = screen.getByText(
+      (_, element) => element?.textContent === "First line\nSecond line"
+    );
+
+    expect(description).toHaveClass("whitespace-pre-wrap");
+  });
+});

--- a/app/bouncer/app/parties/whats-the-move-2026/cloud-party-invitation.tsx
+++ b/app/bouncer/app/parties/whats-the-move-2026/cloud-party-invitation.tsx
@@ -110,7 +110,7 @@ export function CloudPartyInvitation({
               style={dividerStyle}
             >
               <div className="uppercase text-slate-700/80">note</div>
-              <p className="max-w-[68ch] leading-relaxed text-slate-950/90">
+              <p className="max-w-[68ch] whitespace-pre-wrap leading-relaxed text-slate-950/90">
                 {party.description}
               </p>
             </section>


### PR DESCRIPTION
## Summary
- Preserve line breaks in the whats-the-move party description by rendering it with `whitespace-pre-wrap`.
- Add a focused component test that covers multiline party descriptions on the custom invitation page.

## Validation
- `npm test -- --runTestsByPath app/parties/whats-the-move-2026/__tests__/cloud-party-invitation.test.tsx`
- `npm test -- --runTestsByPath app/parties/whats-the-move-2026/__tests__/page.test.tsx`
- `npx prettier --check app/parties/whats-the-move-2026/cloud-party-invitation.tsx app/parties/whats-the-move-2026/__tests__/cloud-party-invitation.test.tsx`