### PR TITLE
[codex] Update homepage party definition

### DIFF
--- a/app/bouncer/app/__tests__/page.test.tsx
+++ b/app/bouncer/app/__tests__/page.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import HomePage from "../page";
+
+jest.mock("@/components/auth/login-button", () => ({
+  LoginButton: () => <button type="button">Sign in</button>,
+}));
+
+describe("HomePage", () => {
+  it("defines party as a mission-oriented group", async () => {
+    const component = await HomePage();
+    render(component);
+
+    expect(
+      screen.getByRole("heading", { name: "a space for my friends", level: 1 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "party", level: 3 })
+    ).toHaveClass("text-2xl");
+    expect(screen.getByText("PAR-tee")).toBeInTheDocument();
+    const definition = screen.getByText(
+      /a group of people assembled to complete a mission together/i
+    );
+
+    expect(definition).toBeInTheDocument();
+    expect(definition.closest("blockquote")).toHaveClass("border-l-4");
+    expect(
+      screen.getByText(
+        /away from the noise of social media, built for the moments/i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/not for the masses/i)).toBeInTheDocument();
+  });
+});

--- a/app/bouncer/app/page.tsx
+++ b/app/bouncer/app/page.tsx
@@ -2,21 +2,34 @@ import { LoginButton } from "@/components/auth/login-button";
 
 export default async function HomePage() {
   return (
-    <div className="">
+    <div>
       <h1 className="tracking-tighter uppercase font-semibold text-4xl mb-3">
         a space for my friends
       </h1>
+      <div className="mt-8 mb-2">
+        <p className="mb-2 uppercase tracking-tighter text-sm">noun</p>
+        <h3 className="tracking-tighter uppercase font-semibold text-2xl mb-3">
+          party
+        </h3>
+      </div>
+      <p className="mb-6 text-lg" aria-label="pronunciation">
+        PAR-tee
+      </p>
+      <blockquote className="mb-7 border-l-4 border-black pl-4">
+        <p>
+          A group of people assembled to complete a mission together; a company
+          bound by shared intent, mutual trust, and the work of showing up.
+        </p>
+      </blockquote>
       <p className="mb-5">
-        I have an amazing group of friends in my life, and I want to create a
-        community away from the noise of social media... A place where we can
-        focus on sharing the moments that actually matter.
+        This is a space for my friends, away from the noise of social media,
+        built for the moments that actually matter.
       </p>
       <p className="mb-5">
-        We are returning to an older paradigm of technology: building not for
-        the masses, but for a hyperlocal group of people. To start, the app will
-        be simple:
+        Not for the masses. For a hyperlocal group of people who show up when
+        there is something to make happen.
       </p>
-      <p className="mb-5">This is an open invitation to any event I host.</p>
+      <p className="mb-5">An open invitation to the next mission.</p>
       <div className="mt-8">
         <LoginButton />
       </div>


### PR DESCRIPTION
## Summary

- Adds a dictionary-style homepage section for the site-specific meaning of `party`.
- Includes the pronunciation, mission-oriented definition, and left-rule quote styling.
- Tightens the supporting copy around friends, social-media noise, and hyperlocal missions.
- Adds a focused homepage test for the copy and hierarchy.

## Validation

- `npm test -- --runTestsByPath app/__tests__/page.test.tsx`
- `npx prettier --check app/page.tsx app/__tests__/page.test.tsx`

## Notes

Unrelated local worktree changes were intentionally left out of this PR.